### PR TITLE
feat: Defining the helper functions to import images efficiently

### DIFF
--- a/game/src/support.py
+++ b/game/src/support.py
@@ -42,3 +42,17 @@ def import_sub_folders(*path):
             for sub_folder in sub_folders:
                 frames[sub_folder] =import_folder(*path,sub_folder)
     return frames
+
+def import_tilemap(cols,rows,*path):
+    frames={}
+    surf=import_image(*path)
+    cell_width=surf.get_width()/cols
+    cell_height=surf.get_height()/rows
+
+    for col in range(cols):
+        for row in range(rows):
+            cutout_rect = pygame.Rect(col*cell_width,row*cell_height,cell_width,cell_height)
+            cutout_surf =pygame.Surface((cell_width,cell_height))
+
+            cutout_surf.blit(surf,(0,0),cutout_rect)
+            frames[(col,row)] =cutout_surf

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -15,8 +15,8 @@ def import_image(*path,alph=True,format="png"):
 def import_folder(*path):
     frames =[]
     for folder_path,sub_folders,image_names in walk(join(*path)):
-        for image_name in sorted(image_names,key=lambda name:name.split('.')[0]):
-            full_path = join(folder_path,image_name)
+        for img_name_with_extension in sorted(image_names,key=lambda name_with_extension:name_with_extension.split('.')[0]):
+            full_path = join(folder_path,img_name_with_extension)
             surface = pygame.image.load(full_path).convert_alpha()
             frames.append(surface)
     return frames

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -20,3 +20,13 @@ def import_folder(*path):
             surface = pygame.image.load(full_path).convert_alpha()
             frames.append(surface)
     return frames
+
+def import_folder_dic(*path):
+    frames ={}
+    for folder_path,sub_folders,image_names in walk(join(*path)):
+        for img_name_with_extension in image_names:
+            full_path = join(folder_path,img_name_with_extension)
+            surface = pygame.image.load(full_path).convert_alpha()
+            image_name = img_name_with_extension.split(".")[0]
+            frames[image_name] = surface
+    return frames

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -1,5 +1,6 @@
 from  settings import *
 from os.path import join,exists
+from os import walk
 
 def import_image(*path,alph=True,format="png"):
     full_path = join(*path) +f".{format}"
@@ -10,3 +11,12 @@ def import_image(*path,alph=True,format="png"):
     else:
         surface =pygame.image.load(full_path).convert()
     return surface
+
+def import_folder(*path):
+    frames =[]
+    for folder_path,sub_folders,image_names in walk(join(*path)):
+        for image_name in image_names:
+            full_path = join(folder_path,image_name)
+            surface = pygame.image.load(full_path).convert_alpha()
+            frames.append(surface)
+    return frames

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -34,3 +34,11 @@ def import_folder_dic(*path):
             image_name = img_name_with_extension.split(".")[0]
             frames[image_name] = surface
     return frames
+
+def import_sub_folders(*path):
+    frames ={}
+    for folder_path,sub_folders,image_names in walk(join(*path)):
+        if sub_folders:
+            for sub_folder in sub_folders:
+                frames[sub_folder] =import_folder(*path,sub_folder)
+    return frames

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -1,0 +1,12 @@
+from  settings import *
+from os.path import join,exists
+
+def import_image(*path,alph=True,format="png"):
+    full_path = join(*path) +f".{format}"
+    print(full_path)
+    print(exists(full_path))
+    if alph:
+        surface =pygame.image.load(full_path).convert_alpha()
+    else:
+        surface =pygame.image.load(full_path).convert()
+    return surface

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -1,31 +1,35 @@
-from  settings import *
-from os.path import join,exists
+from settings import *
+from os.path import join, exists
 from os import walk
 
-def import_image(*path,alph=True,format="png"):
-    full_path = join(*path) +f".{format}"
+
+def import_image(*path, alph=True, format="png"):
+    full_path = join(*path) + f".{format}"
     print(full_path)
     print(exists(full_path))
     if alph:
-        surface =pygame.image.load(full_path).convert_alpha()
+        surface = pygame.image.load(full_path).convert_alpha()
     else:
-        surface =pygame.image.load(full_path).convert()
+        surface = pygame.image.load(full_path).convert()
     return surface
 
+
 def import_folder(*path):
-    frames =[]
-    for folder_path,sub_folders,image_names in walk(join(*path)):
-        for img_name_with_extension in sorted(image_names,key=lambda name_with_extension:name_with_extension.split('.')[0]):
-            full_path = join(folder_path,img_name_with_extension)
+    frames = []
+    for folder_path, sub_folders, image_names in walk(join(*path)):
+        for img_name_with_extension in sorted(image_names,
+                                              key=lambda name_with_extension: name_with_extension.split('.')[0]):
+            full_path = join(folder_path, img_name_with_extension)
             surface = pygame.image.load(full_path).convert_alpha()
             frames.append(surface)
     return frames
 
+
 def import_folder_dic(*path):
-    frames ={}
-    for folder_path,sub_folders,image_names in walk(join(*path)):
+    frames = {}
+    for folder_path, sub_folders, image_names in walk(join(*path)):
         for img_name_with_extension in image_names:
-            full_path = join(folder_path,img_name_with_extension)
+            full_path = join(folder_path, img_name_with_extension)
             surface = pygame.image.load(full_path).convert_alpha()
             image_name = img_name_with_extension.split(".")[0]
             frames[image_name] = surface

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -35,29 +35,31 @@ def import_folder_dic(*path):
             frames[image_name] = surface
     return frames
 
+
 def import_sub_folders(*path):
-    frames ={}
-    for folder_path,sub_folders,image_names in walk(join(*path)):
+    frames = {}
+    for folder_path, sub_folders, image_names in walk(join(*path)):
         if sub_folders:
             for sub_folder in sub_folders:
-                frames[sub_folder] =import_folder(*path,sub_folder)
+                frames[sub_folder] = import_folder(*path, sub_folder)
     return frames
 
-def import_tilemap(cols,rows,*path):
-    frames={}
-    surf=import_image(*path)
-    cell_width=surf.get_width()/cols
-    cell_height=surf.get_height()/rows
+
+def import_tilemap(cols, rows, *path):
+    frames = {}
+    surf = import_image(*path)
+    cell_width = surf.get_width() / cols
+    cell_height = surf.get_height() / rows
 
     for col in range(cols):
         for row in range(rows):
-            cutout_rect = pygame.Rect(col*cell_width,row*cell_height,cell_width,cell_height)
-            cutout_surf =pygame.Surface((cell_width,cell_height))
+            cutout_rect = pygame.Rect(col * cell_width, row * cell_height, cell_width, cell_height)
+            cutout_surf = pygame.Surface((cell_width, cell_height))
 
             # Assigning green colour if the cutout object can't cover the whole area on the surface
             # And asking to ignore the green colour then it won't affect the appearance of the original image
             cutout_surf.fill("green")
             cutout_surf.set_colorkey("green")
 
-            cutout_surf.blit(surf,(0,0),cutout_rect)
-            frames[(col,row)] =cutout_surf
+            cutout_surf.blit(surf, (0, 0), cutout_rect)
+            frames[(col, row)] = cutout_surf

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -54,5 +54,10 @@ def import_tilemap(cols,rows,*path):
             cutout_rect = pygame.Rect(col*cell_width,row*cell_height,cell_width,cell_height)
             cutout_surf =pygame.Surface((cell_width,cell_height))
 
+            # Assigning green colour if the cutout object can't cover the whole area on the surface
+            # And asking to ignore the green colour then it won't affect the appearance of the original image
+            cutout_surf.fill("green")
+            cutout_surf.set_colorkey("green")
+
             cutout_surf.blit(surf,(0,0),cutout_rect)
             frames[(col,row)] =cutout_surf

--- a/game/src/support.py
+++ b/game/src/support.py
@@ -15,7 +15,7 @@ def import_image(*path,alph=True,format="png"):
 def import_folder(*path):
     frames =[]
     for folder_path,sub_folders,image_names in walk(join(*path)):
-        for image_name in image_names:
+        for image_name in sorted(image_names,key=lambda name:name.split('.')[0]):
             full_path = join(folder_path,image_name)
             surface = pygame.image.load(full_path).convert_alpha()
             frames.append(surface)


### PR DESCRIPTION
### Functionality for:
-  Importing a single image and returning its surface
-  Importing all images in-side a folder but not the images sub-folder and returning the result as a list
-  Importing all images in-side a folder but not the images sub-folder and returning the result as a dictionary (image name without extension as the key and image as the value)
- Importing all images in sub-folders and ignoring the images at current folder level and returning the result as a dictionary (sub-folder name as the key and value will be a list which contains all the images inside that sub-folder)
- Importing a tile-map and cutting it out by columns and rows it has and returning a dictionary            (key will be current image [column,row] and cutout image will be the value)